### PR TITLE
More cleanup and comments

### DIFF
--- a/drencher/Cargo.toml
+++ b/drencher/Cargo.toml
@@ -7,3 +7,4 @@ authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 rand = "0.3"
 docopt = "0.6"
 rustc-serialize = "*"
+term-painter = "0.2"

--- a/drencher/src/color.rs
+++ b/drencher/src/color.rs
@@ -1,3 +1,5 @@
+extern crate term_painter;
+
 use std::fmt;
 
 
@@ -12,22 +14,21 @@ impl Color {
             tag: tag,
         }
     }
-
-    pub fn symbol(&self) -> &str {
-        match self.tag {
-            0 => "\u{1b}[41m  \u{1b}(B\u{1b}[m",  // red
-            1 => "\u{1b}[42m  \u{1b}(B\u{1b}[m",  // green
-            2 => "\u{1b}[43m  \u{1b}(B\u{1b}[m",  // yellow
-            3 => "\u{1b}[44m  \u{1b}(B\u{1b}[m",  // blue
-            4 => "\u{1b}[45m  \u{1b}(B\u{1b}[m",  // magenta
-            5 => "\u{1b}[46m  \u{1b}(B\u{1b}[m",  // cyan
-            _ => "X",
-        }
-    }
 }
 
 impl fmt::Display for Color {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.symbol().fmt(f)
+        use self::term_painter::{ToStyle, Attr};
+        use self::term_painter::Color::*;
+
+        Attr::Plain.bg(match self.tag {
+            0 => Red,
+            1 => Green,
+            2 => Yellow,
+            3 => Blue,
+            4 => Magenta,
+            5 => Cyan,
+            _ => White,
+        }).paint("  ").fmt(f)
     }
 }

--- a/drencher/src/solver/exact.rs
+++ b/drencher/src/solver/exact.rs
@@ -1,10 +1,44 @@
+//! Exact Solver
+//!
+//! This solver always finds an optimal solution (with as few moves as
+//! possible). Currently, this solver is very slow and can't really handle
+//! instances of size 8 and above.
+//!
+//! ## Algorithm
+//!
+//! The idea is simple: the solver traverses the whole game tree in order to
+//! find a solution. Traversing is done with breadth-first-search which means
+//! that the first solution we find is optimal. The theoretical game tree has
+//! 'm^c' nodes, where 'm' is the number of moves of one optimal solution and
+//! 'c' is the number of colors. One can easily imagine that trees of bigger
+//! instances are impossible to search through. Therefore we have to implement
+//! some techniques to avoid searching the *whole* tree.
+//!
+//! Currently only one optimization is used: when branching deeper into the
+//! tree, we ensure that the color of the move corresponding to the current
+//! branch, is even a neighbor of the field of cells. If not, the move is
+//! useless and the subtree can be ignored. Obviously.
+//!
+//! ## Representing the tree
+//!
+//! Right now, the tree is not really represented as a tree. Since we're
+//! progressing the tree in BFS, we only need to save the last/current layer.
+//! Each node in this layer is saved as a `State` which saves a board state and
+//! all moves leading to this state.
+//!
+//!
+//!
 use board::Board;
 use color::Color;
 use std::mem;
 use super::{Solver, Solution};
 
+/// Type definition of exact solver. See module documentation for more
+/// information.
 pub struct Exact;
 
+/// Used to represent one node in the game tree. See module documentation for
+/// more information.
 #[derive(Clone)]
 struct State {
     pub moves: Vec<Color>,
@@ -13,14 +47,19 @@ struct State {
 
 impl Solver for Exact {
     fn solve(&self, b: Board) -> Result<Solution, Solution> {
+        // root of the tree: no moves yes, initial board
         let initial = State {
             moves: vec![],
             board: b,
         };
-        let mut states = vec![initial];
-        let mut count = 0;
-        let mut adj_break = 0;
 
+        // the `states` vector will hold the current layer of the tree
+        let mut states = vec![initial];
+
+        // a few counter to output useful information
+        let mut count = 0;
+
+        // BFS until a solution is found
         loop {
             println!(
                 "iteration {} (theory: {})",
@@ -29,25 +68,33 @@ impl Solver for Exact {
             );
             count += 1;
 
+            // in this vector, we will collect all nodes of the next layer
             let mut new_states = Vec::new();
 
-            let mut state_count = 0;
+            // count how many times we ignored a subtree because it's move's
+            // color wasn't adjacent
+            let mut adj_break = 0;
+
+            // for each node in the current layer: add children
             for state in &states {
-                state_count += 1;
+                // if we found a solution, just return
                 if state.board.is_drenched() {
                     return Ok(state.moves.clone());
                 }
 
+                // calculate the adjacent colors from the current board
                 let adjacent_colors = state.board.adjacent_colors();
 
                 for color in 0..6 {
                     let color = Color::new(color);
 
+                    // maybe this color isn't even adjacent
                     if !adjacent_colors.contains_key(&color) {
                         adj_break += 1;
                         continue;
                     }
 
+                    // create the new state and push as a child
                     let mut next = state.clone();
                     next.moves.push(color);
                     next.board.drench(color);
@@ -58,10 +105,10 @@ impl Solver for Exact {
             println!(
                 "we broke {}/{} times ",
                 adj_break,
-                state_count * 6
+                states.len() * 6
             );
 
-
+            // proceed with the next layer
             mem::swap(&mut new_states, &mut states);
         }
     }

--- a/drencher/src/solver/mod.rs
+++ b/drencher/src/solver/mod.rs
@@ -14,8 +14,10 @@ pub type Solution = Vec<Color>;
 
 /// Something that can solve our game from an initial board.
 pub trait Solver {
-    /// Given a board, the solver has to return a list of moves that will
-    /// win the game.
+    /// Given a board, the solver has to return a list of moves. Those moves
+    /// either win the game (`Ok(..)`) or don't (`Err(..)`), in which case the
+    /// solver wasn't able to find a winning solution. The `Err` value can
+    /// still contain a solution vector.
     fn solve(&self, b: Board) -> Result<Solution, Solution>;
 
     /// Returns true if the solver already outputs every step of the game. This


### PR DESCRIPTION
Color output is now done with `term-painter` to get platform independent color output and avoid hard coded colors strings. Also: comments and descriptions.
