### PR TITLE
Add method to generate all permutations of a board

### DIFF
--- a/drencher/src/bench.rs
+++ b/drencher/src/bench.rs
@@ -36,7 +36,7 @@ pub fn run_benchmark(
         (0..count).into_par_iter().weight(weight).map(|i| {
 
             // generate board and get player
-            let board = match gen_board(init_algo, size, i as u32) {
+            let board = match gen_board(init_algo, size, i as u64) {
                 Ok(board) => board,
                 Err(_) => return None,
             };

--- a/drencher/src/board.rs
+++ b/drencher/src/board.rs
@@ -34,7 +34,24 @@ impl Board {
         Self::with_rng(size, &mut rng)
     }
 
-    pub fn deterministic_random(size: u8, id: u32) -> Board {
+    /// Returns the nth permutation of a board with the given size. Note that
+    /// there are 6^(size^2) permutations (many!). The number of permutations
+    /// is greater than u64::MAX for size=5 already!
+    pub fn permutation(size: u8, mut n: u64) -> Board {
+        let mut cells = vec![Color::new(0); (size as usize).pow(2)];
+
+        for cell in &mut cells {
+            *cell = Color::new((n % 6) as u8);
+            n /= 6;
+        }
+        Board {
+            size: size,
+            cells: cells,
+        }
+    }
+
+    pub fn deterministic_random(size: u8, id: u64) -> Board {
+        let id = (id & ::std::u32::MAX as u64) as u32;
         let mut rng = IsaacRng::from_seed(&[id, id + 42, id + 27, id + 1337]);
         Self::with_rng(size, &mut rng)
     }

--- a/drencher/src/main.rs
+++ b/drencher/src/main.rs
@@ -143,10 +143,12 @@ fn play_standard_mode(init_algo: &str, size: u8, player: &str)
     Ok(())
 }
 
-fn gen_board(init_algo: &str, size: u8, id: u32) -> Result<Board, ()> {
+fn gen_board(init_algo: &str, size: u8, id: u64) -> Result<Board, ()> {
     match init_algo {
         "random" => Ok(Board::random(size)),
         "deter0" => Ok(Board::deterministic_random(size, id)),
+        "uniform" => Ok(Board::uniform(size)),
+        "permutations" => Ok(Board::permutation(size, id)),
         other => {
             println!("Intial board algorithm '{}' doesn't exist!", other);
             Err(())


### PR DESCRIPTION
(and hot fixed a bug in exact player)

With this permutation method we can hopefully find out the worst case board for size=2 and size=3. However, to find it out the worst case of bigger boards, we have to drastically reduce the number of permutations by eliminating equivalent boards. The number of permutations of a 4*4 board is ~2800Mrd
